### PR TITLE
Fixed missing arguments to string.format call

### DIFF
--- a/src/util/registry.lua
+++ b/src/util/registry.lua
@@ -307,7 +307,7 @@ do
 		return setmetatable( base or {}, {
 			__index = function( self, k )
 				local key = tostring( k )
-				local newtypekey = string.format( "%s.%s._type" )
+				local newtypekey = string.format( "%s.%s._type", name, key )
 				local newformat = HasKey( newtypekey )
 				local vtype = GetString( newformat and newtypekey or string.format( "%s.%s.type", name, key ) )
 				if vtype == "" then


### PR DESCRIPTION
The same `%s.%s._type` style is used later in this same helper method for storing values at line 333, presumably they should match

## Summary of testing issue

If you try using `string.format` without supplying the appropriate parameters, it throws an error, so I'm uncertain how this was not an issue before.

Code tested:
```lua
print( string.format( "%s.%s._type" ) )
```
Result:
```text
input:1: bad argument #2 to 'format' (no value)
```

## Summary of fix

Fix to code proposed: Add in `name` and `key` to fill the `%s` spots, just as it is done on line 333

Code tested:
```lua
local name = "name"
local key = "key"
print( string.format( "%s.%s._type", name, key ) )
```
Result:
```text
name.key._type
```